### PR TITLE
DOC: refresh API and core docs to match current implementation

### DIFF
--- a/docs/api/api_endpoints.md
+++ b/docs/api/api_endpoints.md
@@ -1,31 +1,37 @@
-# EdgeWARN API v2 Documentation
+# EdgeWARN API v2 Endpoints
 
-This document describes the EdgeWARN API v2 endpoints, their parameters, and responses. The API provides access to storm cell data, alerts, and METAR observations.
+This document describes the currently implemented API routes in `src/EdgeWARN/api`.
 
 ## API Overview
 
 - **Base URL**: `/api/v2`
-- **Version**: 2.0.0
+- **Version string**:
+  - `2.x` when `NODE_ENV=production`
+  - `2.0.0-alpha` otherwise
 - **Protocol**: HTTP/HTTPS
-- **Response Format**: JSON
+- **Response format**: JSON
 
-## Root Endpoint
+## Root Endpoints
+
+### GET /
+
+Returns the backend API banner.
+
+```json
+{
+  "message": "EdgeWARN Backend API",
+  "version": "2.0.0-alpha"
+}
+```
 
 ### GET /api/v2
 
-Returns information about the API version and available endpoints.
+Returns API v2 metadata and endpoint map.
 
-**Example Request**:
-```http
-GET /api/v2 HTTP/1.1
-Host: api.edgewarn.com
-```
-
-**Response**:
 ```json
 {
   "message": "EdgeWARN API v2",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha",
   "endpoints": {
     "features": {
       "cells": "/api/v2/features/cells[?id={int}]",
@@ -44,249 +50,120 @@ Host: api.edgewarn.com
 
 ## Features Endpoints
 
-### Cells
+### GET /api/v2/features/cells
 
-#### GET /api/v2/features/cells
+Query parameters:
 
-Returns storm cell data.
+- `id` (optional): positive integer
 
-**Query Parameters**:
-- `id` (optional): Integer - Cell ID to fetch specific cell data
+Behavior:
 
-**Responses**:
+- Without `id`, returns an array of available cell IDs from `cell_index.json`.
+- With `id`, returns that cell JSON (`{id}.json`).
 
-1. Without `id` parameter: Returns array of available cell IDs
+Common errors:
 
-```http
-GET /api/v2/features/cells HTTP/1.1
-Host: api.edgewarn.com
-```
+- `400` invalid `id`
+- `404` cell not found
+- `500` file read/server error
 
-```json
-[12345, 12346, 12347]
-```
+Cache headers:
 
-2. With `id` parameter: Returns specific cell data
+- `max-age=5` (index list)
+- `max-age=60` (single cell)
 
-```http
-GET /api/v2/features/cells?id=12345 HTTP/1.1
-Host: api.edgewarn.com
-```
+### GET /api/v2/features/timestamps
 
-```json
-{
-  "id": 12345,
-  "type": "Feature",
-  "geometry": {
-    "type": "Polygon",
-    "coordinates": [...]
-  },
-  "properties": {
-    "centroid": [35.0, -97.0],
-    "max_refl": 55,
-    "num_gates": 25,
-    "timestamp": "2023-10-01T12:00:00Z",
-    "velocity": {
-      "u": 5.0,
-      "v": 3.0,
-      "speed": 5.83,
-      "bearing": 59.0
-    },
-    "confidence": 0.95,
-    "tracking_mode": "active",
-    "event_type": "ACTIVE",
-    "alerts": ["TOR", "HAIL"]
-  }
-}
-```
+Query parameters:
 
-### Timestamps
+- `timestamp` (optional): `YYYYMMDD-HHMMSS`
 
-#### GET /api/v2/features/timestamps
+Behavior:
 
-Returns available timestamps or storm cell data for a specific timestamp.
+- Without `timestamp`, returns available timestamps from `stormcell_index.json`.
+- With `timestamp`, returns `stormcells_{timestamp}.json`.
 
-**Query Parameters**:
-- `timestamp` (optional): String - Timestamp in `YYYYMMDD-HHMMSS` format
+Common errors:
 
-**Responses**:
+- `400` invalid timestamp
+- `404` timestamp file not found
+- `500` file read/server error
 
-1. Without `timestamp` parameter: Returns array of available timestamps
+Cache headers:
 
-```http
-GET /api/v2/features/timestamps HTTP/1.1
-Host: api.edgewarn.com
-```
+- `max-age=5` (timestamp index)
+- `max-age=3600` (stormcell snapshot)
 
-```json
-["20231001-120000", "20231001-115800", "20231001-115600"]
-```
+### GET /api/v2/features/alerts/official
 
-2. With `timestamp` parameter: Returns storm cell data for that timestamp
+### GET /api/v2/features/alerts/edgewarn
 
-```http
-GET /api/v2/features/timestamps?timestamp=20231001-120000 HTTP/1.1
-Host: api.edgewarn.com
-```
+Query parameters (mutually exclusive):
 
-```json
-{
-  "type": "FeatureCollection",
-  "features": [
-    {
-      "id": 12345,
-      "type": "Feature",
-      "geometry": {...},
-      "properties": {...}
-    }
-  ],
-  "latest_timestamp": "2023-10-01T12:00:00Z"
-}
-```
+- `timestamp` (optional): `YYYYMMDD-HHMMSS`
+- `id` (optional): alert ID string
 
-### Alerts
+Behavior:
 
-#### GET /api/v2/features/alerts/official
+- Without params: returns available snapshot timestamps from the alerts timestamp directory.
+- With `timestamp`: returns list of alert IDs for that timestamp (`[]` if snapshot missing).
+- With `id`: returns full alert feature payload for that ID.
 
-Returns official NWS alerts.
+Validation and errors:
 
-**Query Parameters**:
-- `id` (optional): String - Alert ID (URN format: `urn:oid:12345`)
-- `timestamp` (optional): String - Timestamp in `YYYYMMDD-HHMMSS` format
+- `400` if both `id` and `timestamp` are supplied
+- `400` invalid `id` or `timestamp`
+- `404` unknown alert `id`
+- `500` server error
 
-**Responses**:
+Notes:
 
-1. Without parameters: Returns array of available timestamps
+- Alert error responses are wrapped in `{ success: false, error: { code, message } }`.
+- Alert IDs are resolved from filename-safe transformations (`:` and `/` replaced with `_`).
 
-```http
-GET /api/v2/features/alerts/official HTTP/1.1
-Host: api.edgewarn.com
-```
+Cache headers:
 
-```json
-["20231001-120000", "20231001-115800", "20231001-115600"]
-```
-
-2. With `timestamp` parameter: Returns alert IDs for that timestamp
-
-```http
-GET /api/v2/features/alerts/official?timestamp=20231001-120000 HTTP/1.1
-Host: api.edgewarn.com
-```
-
-```json
-["urn:oid:12345", "urn:oid:12346"]
-```
-
-3. With `id` parameter: Returns specific alert data
-
-```http
-GET /api/v2/features/alerts/official?id=urn:oid:12345 HTTP/1.1
-Host: api.edgewarn.com
-```
-
-```json
-{
-  "id": "urn:oid:12345",
-  "type": "Feature",
-  "geometry": {
-    "type": "Polygon",
-    "coordinates": [...]
-  },
-  "properties": {
-    "event": "Tornado Warning",
-    "severity": "Severe",
-    "sender": "NWS",
-    "sent": "2023-10-01T12:00:00Z",
-    "effective": "2023-10-01T12:00:00Z",
-    "expires": "2023-10-01T12:30:00Z",
-    "headline": "Tornado Warning issued for Westchester County"
-  }
-}
-```
-
-#### GET /api/v2/features/alerts/edgewarn
-
-Returns EdgeWARN generated alerts (same interface as official alerts).
-
-**Query Parameters**:
-- `id` (optional): String - Alert ID
-- `timestamp` (optional): String - Timestamp in `YYYYMMDD-HHMMSS` format
-
-**Responses**:
-Same format as official alerts endpoint.
+- `max-age=5` (timestamp listing)
+- `max-age=60` (`id` and `timestamp` lookups)
 
 ## Data Endpoints
 
-### METAR
+### GET /api/v2/data/metar
 
-#### GET /api/v2/data/metar
+Query parameters:
 
-Returns METAR weather observations.
+- `timestamp` (optional): `YYYYMMDD-HHMMSS`
 
-**Query Parameters**:
-- `timestamp` (optional): String - Timestamp in `YYYYMMDD-HHMMSS` format
+Behavior:
 
-**Responses**:
-
-1. Without `timestamp` parameter: Returns array of available timestamps
-
-```http
-GET /api/v2/data/metar HTTP/1.1
-Host: api.edgewarn.com
-```
-
-```json
-["20231001-120000", "20231001-110000", "20231001-100000"]
-```
-
-2. With `timestamp` parameter: Returns METAR data for that timestamp
-
-```http
-GET /api/v2/data/metar?timestamp=20231001-120000 HTTP/1.1
-Host: api.edgewarn.com
-```
+- Without `timestamp`, returns available METAR timestamps derived from files matching `METAR_YYYYMMDD-HHz.json`.
+- With `timestamp`, returns:
 
 ```json
 {
   "type": "metar",
-  "timestamp": "20231001-120000",
-  "data": [
-    {
-      "station": "KJFK",
-      "name": "John F. Kennedy International Airport",
-      "latitude": 40.64,
-      "longitude": -73.78,
-      "observation_time": "2023-10-01T12:00:00Z",
-      "temperature": 20.0,
-      "dewpoint": 15.0,
-      "wind": {
-        "direction": 180,
-        "speed": 10,
-        "gust": null
-      },
-      "visibility": 10,
-      "pressure": 1013,
-      "sky_conditions": "Few clouds at 3000ft",
-      "flight_category": "VFR"
-    }
-  ]
+  "timestamp": "YYYYMMDD-HHMMSS",
+  "data": []
 }
 ```
 
-## Health Check
+Common errors:
 
-#### GET /health
+- `400` invalid timestamp
+- `404` METAR file not found
+- `500` file read/server error
 
-Returns server health status.
+Cache headers:
 
-**Example Request**:
-```http
-GET /health HTTP/1.1
-Host: api.edgewarn.com
-```
+- `max-age=5` (timestamp listing)
+- `max-age=60` (timestamp file)
 
-**Response**:
+## Other Routes
+
+### GET /health
+
+Returns service health:
+
 ```json
 {
   "status": "OK",
@@ -294,35 +171,20 @@ Host: api.edgewarn.com
 }
 ```
 
-## Error Handling
+### GET /robots.txt
 
-The API returns appropriate HTTP status codes for errors:
+Serves `src/EdgeWARN/api/robots.txt`.
 
-- **400 Bad Request**: Invalid parameters or input
-- **404 Not Found**: Resource not found
-- **500 Internal Server Error**: Server-side error
+### Legacy v1 routes
 
-**Example Error Response**:
-```json
-{
-  "error": "Invalid id parameter. Must be a positive integer"
-}
-```
+- `/features/*`
+- `/data/*`
 
-## Caching
+Return `410 Gone` with guidance to use `/api/v2`.
 
-The API uses caching to improve performance:
+## Security and Platform Behavior
 
-- Cell data: 60 seconds
-- Alert data: 60 seconds
-- Metar data: 60 seconds
-- Timestamps: 5 seconds
-- Index files: 5 seconds
-
-## Rate Limiting
-
-The API is rate limited to 60 requests per minute per IP address by default. This can be configured via environment variables.
-
-## Cross-Origin Resource Sharing (CORS)
-
-CORS is configured to allow requests from specific origins. In development, this includes `http://localhost:3000` and `http://localhost:8080`. In production, origins must be explicitly configured via the `ALLOWED_ORIGINS` environment variable.
+- Rate limiting is enabled globally via `express-rate-limit` (defaults: 60 requests / minute / client key).
+- CORS is allowlist-based via `ALLOWED_ORIGINS`.
+- Helmet security headers and compression are enabled.
+- In production, detailed version strings are intentionally hidden (`2.x`).

--- a/docs/api/api_implementation.md
+++ b/docs/api/api_implementation.md
@@ -1,284 +1,181 @@
 # EdgeWARN API v2 Technical Implementation
 
-This document describes the technical implementation of the EdgeWARN API v2, including the server architecture, middleware, routing, and utility functions.
+This document describes the current implementation in `src/EdgeWARN/api`.
 
 ## Server Architecture
 
-The EdgeWARN API is built with Node.js and Express.js, using a modular architecture. The server is designed to be scalable, secure, and efficient.
+The API is an Express.js service with clustered workers (up to 4), file-backed data access, and defensive request validation.
 
 ### File Structure
 
 ```
 src/EdgeWARN/api/
-├── server.js                    # Main server entry point
-├── config.js                    # Configuration and directory setup
-├── robots.txt                   # Robots.txt for search engines
+├── server.js
+├── config.js
+├── robots.txt
 ├── routes/
-│   ├── health.js                # Health check route
+│   ├── health.js
 │   └── v2/
-│       ├── index.js             # API v2 router
+│       ├── index.js
 │       ├── features/
-│       │   ├── cells.js         # Cells endpoint
-│       │   ├── alerts.js        # Alerts endpoint
-│       │   └── timestamps.js    # Timestamps endpoint
+│       │   ├── cells.js
+│       │   ├── alerts.js
+│       │   └── timestamps.js
 │       └── data/
-│           └── metar.js         # METAR endpoint
+│           └── metar.js
 └── utils/
-    ├── fileReader.js            # File reading and caching utilities
-    └── validation.js            # Input validation utilities
+    ├── fileReader.js
+    └── validation.js
 ```
 
-## Server Configuration
+## Request Lifecycle
 
-### server.js
+1. `server.js` loads environment variables (`dotenv`) and config.
+2. If process is primary, Node cluster forks up to 4 workers.
+3. Each worker applies middleware:
+   - `helmet`
+   - `compression`
+   - `cors` (allowlist from `ALLOWED_ORIGINS`)
+   - `express.json()`
+   - `express-rate-limit`
+4. Worker mounts routes:
+   - `/`
+   - `/health`
+   - `/api/v2`
+   - legacy guards for `/features/*` and `/data/*` returning `410`
+5. File-backed routes fetch JSON from configured data directories using safe readers.
 
-The main server entry point that sets up the Express application with all middleware and routes.
+## Configuration (`config.js`)
 
-**Key Features**:
-- Cluster support for multi-core processing
-- Security middleware (Helmet)
-- Compression middleware
-- CORS configuration
-- Rate limiting
-- Error handling
-- Route mounting
+`config.js` resolves `BASE_DIR` in this order:
 
-**Cluster Configuration**:
-The server uses Node.js clustering to take advantage of multiple CPU cores. By default, it forks up to 4 workers.
+1. CLI arg: `--base-dir` / `--base-dir=...`
+2. `EDGEWARN_BASE_DIR`
+3. Platform defaults (including `~/EdgeWARN_input` on non-Windows)
 
-```javascript
-const numCPUs = Math.min(os.cpus().length, 4);
-```
+It then builds `DATA_DIR` subpaths (cells, stormcells, METAR, alerts, etc.) and creates missing directories at startup.
 
-### config.js
+It also supports debug mode via `--debug_server`:
 
-Handles application configuration, including:
-- Base directory detection
-- Directory paths for data storage
-- Debug server mode
-- Port configuration
-- Directory validation and creation
-
-**Base Directory Detection Order**:
-1. CLI argument `--base-dir`
-2. Environment variable `EDGEWARN_BASE_DIR`
-3. Platform-specific defaults:
-   - Windows: `C:\EdgeWARN_input`
-   - Linux/macOS: User home directory, then common locations
+- default port: `5000`
+- debug port: `3001`
 
 ## Routing
 
-### v2/index.js
+### `routes/v2/index.js`
 
-The main API v2 router that mounts all feature and data routes.
+Mounts:
 
-```javascript
-import express from 'express';
-import cellsRouter from './features/cells.js';
-import timestampsRouter from './features/timestamps.js';
-import alertsRouter from './features/alerts.js';
-import metarRouter from './data/metar.js';
+- `/features/cells`
+- `/features/timestamps`
+- `/features/alerts`
+- `/data/metar`
 
-const router = express.Router();
+And provides `GET /api/v2` endpoint metadata.
 
-router.use('/features/cells', cellsRouter);
-router.use('/features/timestamps', timestampsRouter);
-router.use('/features/alerts', alertsRouter);
-router.use('/data/metar', metarRouter);
-```
+### `routes/v2/features/cells.js`
 
-### Feature Routes
+- `GET /api/v2/features/cells`
+- Optional query: `id`
+- Reads `cell_index.json` for list mode.
+- Reads `{id}.json` for single-cell mode.
+- Validates positive integer IDs.
 
-#### cells.js
+### `routes/v2/features/timestamps.js`
 
-Handles cell data retrieval.
+- `GET /api/v2/features/timestamps`
+- Optional query: `timestamp` (`YYYYMMDD-HHMMSS`)
+- Reads `stormcell_index.json` for list mode.
+- Reads `stormcells_{timestamp}.json` for snapshot mode.
 
-**Key Functions**:
-- `GET /api/v2/features/cells` - Returns cell IDs or specific cell data
-- Validates cell ID parameter
-- Caches cell data for 60 seconds
-- Reads data from `cell_index.json` and individual cell files
+### `routes/v2/features/alerts.js`
 
-#### alerts.js
+- `GET /api/v2/features/alerts/official`
+- `GET /api/v2/features/alerts/edgewarn`
+- Supports mutually exclusive query params: `id` or `timestamp`
+- ID mode resolves filename-safe IDs in `ids/`
+- Timestamp mode reads `{timestamp}.json` from `timestamps/`
+- List mode scans timestamp files and returns sorted timestamp keys
 
-Handles alert data retrieval for both official NWS alerts and EdgeWARN alerts.
+### `routes/v2/data/metar.js`
 
-**Key Functions**:
-- `GET /api/v2/features/alerts/official` - Returns official NWS alerts
-- `GET /api/v2/features/alerts/edgewarn` - Returns EdgeWARN alerts
-- Handles both `id` and `timestamp` query parameters
-- Validates input parameters
-- Caches alert data for 60 seconds
+- `GET /api/v2/data/metar`
+- Optional query: `timestamp`
+- List mode scans `METAR_YYYYMMDD-HHz.json`
+- Timestamp mode maps request to hourly METAR file and wraps result as `{ type, timestamp, data }`
 
-#### timestamps.js
+### `routes/health.js`
 
-Handles timestamp data retrieval and storm cell data by timestamp.
+- `GET /health` returns service status and server timestamp.
 
-**Key Functions**:
-- `GET /api/v2/features/timestamps` - Returns available timestamps
-- `GET /api/v2/features/timestamps?timestamp={YYYYMMDD-HHMMSS}` - Returns storm cell data for specific timestamp
-- Reads from `stormcell_index.json`
-- Caches data for 5 seconds (timestamps) or 1 hour (stormcell data)
+## Utilities
 
-### Data Routes
+### `utils/fileReader.js`
 
-#### metar.js
+Provides:
 
-Handles METAR weather observation retrieval.
+- `isSafeFilename(name)` filename hardening
+- `readJsonFileSafe(dir, name, options)` safe JSON file reads with traversal protection
+- `readIndexFile(path)` index-file reads with short cache TTL
 
-**Key Functions**:
-- `GET /api/v2/data/metar` - Returns available timestamps
-- `GET /api/v2/data/metar?timestamp={YYYYMMDD-HHMMSS}` - Returns METAR data for specific timestamp
-- Handles hourly METAR files
-- Formats timestamps from `YYYYMMDD-HH` to `YYYYMMDD-HHMMSS`
+Caching uses `lru-cache`:
 
-### Health Route
+- max entries: `500`
+- default TTL: `60s`
+- max worker cache size: `40MB`
+- index TTL override: `5s`
 
-#### health.js
+### `utils/validation.js`
 
-Simple health check endpoint.
+Centralized validation helpers for:
 
-```javascript
-router.get('/', (req, res) => {
-  res.json({
-    status: 'OK',
-    timestamp: new Date().toISOString()
-  });
-});
-```
+- resource type checks
+- timestamp validation
+- mutually exclusive query params
+- cell ID and alert ID validation
 
-## Utility Functions
+## Middleware Details
 
-### fileReader.js
+### Security
 
-Provides safe file reading with path traversal protection and caching.
-
-**Key Functions**:
-- `isSafeFilename(name)` - Validates filename to prevent path traversal
-- `readJsonFileSafe(dir, name, options)` - Reads JSON file with traversal protection
-- `readIndexFile(indexPath)` - Reads index files with shorter cache TTL
-
-**Caching**:
-Uses `lru-cache` with:
-- Max 500 items
-- Default TTL: 1 minute (60,000 ms)
-- Max size: 40 MB per worker
-
-Index files (cell_index.json, stormcell_index.json) have a shorter TTL of 5 seconds.
-
-### validation.js
-
-Provides input validation utilities.
-
-**Key Functions**:
-- `validateResourceType(type)` - Validates resource type
-- `validateTimestamp(timestamp)` and `validateTimestampV2(timestamp)` - Validates timestamp format
-- `validateMutualExclusion(params, key1, key2)` - Ensures parameters are mutually exclusive
-- `validateCellId(id)` - Validates cell ID is a positive integer
-- `validateAlertId(id)` - Validates alert ID format and prevents prototype pollution
-
-## Middleware
-
-### Security (Helmet)
-
-```javascript
-app.use(helmet({
-  hsts: {
-    maxAge: 31536000, // 1 year
-    includeSubDomains: true
-  },
-  contentSecurityPolicy: {
-    useDefaults: true,
-    directives: {
-      "default-src": ["'self'"],
-    }
-  }
-}));
-```
+`helmet` is enabled with HSTS and CSP defaults.
 
 ### CORS
 
-```javascript
-const allowedOrigins = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim())
-  : (process.env.NODE_ENV === 'production' ? [] : ['http://localhost:3000', 'http://localhost:8080']);
-
-app.use(cors({
-  origin: allowedOrigins.length > 0 ? allowedOrigins : false,
-  credentials: true,
-  methods: ['GET', 'HEAD', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization']
-}));
-```
+- In non-production without env override: localhost allowlist
+- In production: requires explicit `ALLOWED_ORIGINS`, otherwise cross-origin requests are blocked
 
 ### Rate Limiting
 
-```javascript
-const limiter = rateLimit({
-  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) || 60 * 1000, // 1 minute
-  max: parseInt(process.env.RATE_LIMIT_MAX, 10) || 60, // 60 requests
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: 'Too many requests, please try again later' },
-  // Skip rate limiting for health checks from internal monitoring
-  skip: (req) => {
-    return req.path === '/health' && req.headers['x-internal-check'] === 'true';
-  },
-  // Custom key generator to handle proxy environments
-  keyGenerator: (req) => {
-    // ...
-  }
-});
-```
+`express-rate-limit` defaults:
 
-## Performance Optimizations
+- `RATE_LIMIT_WINDOW_MS`: `60000`
+- `RATE_LIMIT_MAX`: `60`
 
-1. **Clustering**: Takes advantage of multi-core processors
-2. **Caching**: LRU cache for frequent requests
-3. **Compression**: Gzip compression for responses
-4. **Efficient File Reading**: Optimized with fs.promises and cache
-5. **Path Traversal Protection**: Validates filenames and paths
+Special cases:
+
+- Optional skip for `/health` with `x-internal-check: true`
+- Custom key generation handles proxy/non-proxy deployments
 
 ## Error Handling
 
-```javascript
-app.use((err, req, res, next) => {
-  const isDev = process.env.NODE_ENV !== 'production';
-  console.error(isDev ? err.stack : `Error: ${err.message}`);
-  res.status(500).json({
-    error: isDev ? err.message : 'Internal server error'
-  });
-});
-```
-
-Error responses are sanitized in production to prevent information leakage.
+- Route-level handlers return `400/404/500` as appropriate.
+- Global error middleware sanitizes output in production (`Internal server error`).
+- Legacy v1 paths return `410 Gone` and include migration guidance.
 
 ## Environment Variables
 
-Key environment variables:
-- `PORT`: Server port
-- `NODE_ENV`: Environment (development/production)
-- `ALLOWED_ORIGINS`: CORS allowed origins
-- `RATE_LIMIT_WINDOW_MS`: Rate limit window
-- `RATE_LIMIT_MAX`: Rate limit maximum requests
-- `TRUST_PROXY`: Whether to trust proxy headers
-- `TRUST_PROXY_IPS`: Specific proxy IPs to trust
-- `EDGEWARN_BASE_DIR`: Base directory for data
+- `PORT`
+- `NODE_ENV`
+- `ALLOWED_ORIGINS`
+- `RATE_LIMIT_WINDOW_MS`
+- `RATE_LIMIT_MAX`
+- `TRUST_PROXY`
+- `TRUST_PROXY_IPS`
+- `EDGEWARN_BASE_DIR`
 
-## Debug Server Mode
+## Runtime Modes
 
-The server can be run in debug mode using:
-
-```bash
-npm run debug
-```
-
-Debug mode uses port 3001 instead of 5000 and provides more detailed error messages.
-
-## Deployment
-
-The API can be deployed using:
-
-1. **Production**: `npm start`
-2. **Development**: `npm run dev` (with watch mode)
-3. **Debug**: `npm run debug`
+- **Production**: `npm start`
+- **Development watch**: `npm run dev`
+- **Debug**: `npm run debug`

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -1,331 +1,95 @@
 # EdgeWARN Core Modules Documentation
 
-The core directory contains the main processing modules for EdgeWARN. These modules are responsible for data ingestion, storm detection and tracking, and data integration from various meteorological sources. Together, they form the processing pipeline that takes raw meteorological data and transforms it into actionable severe weather information.
+This document summarizes the currently implemented core package layout under `src/EdgeWARN/core`.
 
-## Project Overview
-
-EdgeWARN is a severe weather nowcasting system developed by the Edgemont Weather Service. It combines data from multiple sources to accurately detect, track, and analyze severe weather events in real-time. The core modules work together to process radar data, satellite imagery, lightning data, and model outputs to provide detailed storm cell information and threat assessments.
-
-## Module Collaboration and Data Flow
-
-```mermaid
-graph TD
-    A[Ingestion Module] -->|Downloads and Parses| B[MRMS Radar Data]
-    A -->|Downloads and Parses| C[NWS Alerts]
-    A -->|Downloads and Parses| D[GOES-19 GLM Lightning]
-    A -->|Downloads and Parses| E[RAP Synoptic Data]
-    A -->|Downloads and Parses| F[METAR Observations]
-    
-    B --> G[Detection Module]
-    C --> G
-    G -->|Detects and Tracks| H[Storm Cells]
-    
-    H --> I[Integration Module]
-    D --> I
-    E --> I
-    F --> I
-    B --> I
-    
-    I -->|Fuses Data| J[Integrated Storm Properties]
-    
-    J --> K[CTAM Analysis]
-    K -->|Threat Assessment| L[Storm Hazards]
-    
-    L --> M[Alerts Module]
-    J --> M
-    
-    M -->|Generates| N[Severe Weather Alerts]
-    
-    N --> O[API Serving]
-```
-
-## Core Module Functions and Final Products
-
-### 1. Ingestion Module (/core/ingest/)
-
-**Purpose**: Collects and processes raw meteorological data from various sources.
-
-**Key Functions**:
-- Downloads MRMS radar data from AWS S3
-- Fetches NWS alerts from the National Weather Service API
-- Downloads GOES-19 GLM lightning data
-- Retrieves RAP synoptic model data
-- Collects METAR observations from aviation weather sources
-
-**Final Products**:
-- Organized raw data files in specified directories
-- Cleaned and validated datasets ready for processing
-- Cached files for performance optimization
-
-**Output Examples**:
-```
-EdgeWARN_input/
-├── mrms/                      # MRMS radar products
-│   ├── reflectivity/          # Merged Reflectivity Composite
-│   ├── probsevere/            # ProbSevere v3 data
-│   └── precip_type/           # Precipitation Type
-├── nws/                       # NWS alerts and warnings
-├── goes/                      # GOES-19 satellite data
-│   └── glm/                   # GLM lightning data
-└── rap/                       # RAP synoptic model data
-```
-
-### 2. Detection Module (/core/process/detect/)
-
-**Purpose**: Identifies and tracks storm cells from raw radar and model data.
-
-**Key Functions**:
-- Detects storm cells from radar reflectivity data
-- Tracks storm movement using Kalman filtering
-- Handles storm cell merge and split events
-- Manages storm cell lineage and history
-- Matches detected storms to NWS alerts
-
-**Final Products**:
-- Storm cell detection results with unique identifiers
-- Track information including velocity and direction
-- Confidence scores for each detection
-- Lineage information (evolution history)
-- Alert associations
-
-**Output Format**:
-```json
-{
-  "type": "FeatureCollection",
-  "features": [
-    {
-      "id": "12345",
-      "type": "Feature",
-      "geometry": {
-        "type": "Polygon",
-        "coordinates": [...]
-      },
-      "properties": {
-        "centroid": [35.0, -97.0],
-        "max_refl": 55,
-        "num_gates": 25,
-        "timestamp": "2023-10-01T12:00:00Z",
-        "velocity": {
-          "u": 5.0,
-          "v": 3.0,
-          "speed": 5.83,
-          "bearing": 59.0
-        },
-        "confidence": 0.95,
-        "tracking_mode": "active",
-        "event_type": "ACTIVE",
-        "alerts": ["TOR", "HAIL"]
-      }
-    }
-  ],
-  "latest_timestamp": "2023-10-01T12:00:00Z"
-}
-```
-
-### 3. Integration Module (/core/process/integrate/)
-
-**Purpose**: Fuses data from multiple sources to create comprehensive storm cell properties.
-
-**Key Functions**:
-- Integrates GOES-19 GLM lightning data
-- Fuses RAP synoptic model data
-- Incorporates ProbSevere v3 data
-- Calculates integrated storm properties
-- Performs quality control and error handling
-
-**Final Products**:
-- Comprehensive storm cell properties including:
-  - Basic storm information (location, size, intensity)
-  - Track information (velocity, direction)
-  - Lightning properties (flash rate, density, energy)
-  - Environmental parameters (CAPE, CIN, shear)
-  - Threat assessment metrics (hail potential, tornado potential)
-  - Quality control and uncertainty estimates
-
-**Output Format**:
-```json
-{
-  "type": "FeatureCollection",
-  "features": [
-    {
-      "id": "12345",
-      "type": "Feature",
-      "geometry": {...},
-      "properties": {
-        "centroid": [35.0, -97.0],
-        "max_refl": 55,
-        "num_gates": 25,
-        "timestamp": "2023-10-01T12:00:00Z",
-        "ProbSevere": 0.85,
-        "ProbWind": 0.70,
-        "ProbHail": 0.65,
-        "ProbTor": 0.40,
-        "GLM_FLASH_COUNT": 15,
-        "GLM_TOTAL_ENERGY": 1250.5,
-        "CAPE": 2500,
-        "CIN": -50,
-        "EBShear": 35,
-        "MESH": 3.5,
-        "VIL": 50
-      }
-    }
-  ],
-  "latest_timestamp": "2023-10-01T12:00:00Z"
-}
-```
-
-### 4. Alerts Module (/core/alerts/)
-
-**Purpose**: Manages alert generation and dissemination.
-
-**Key Functions**:
-- Generates severe weather alerts based on storm properties
-- Manages alert schema definitions
-- Handles alert storage and retrieval
-- Provides alert matching and verification
-
-### 5. CTAM (Convective Threat Analysis Module) (/core/ctam/)
-
-**Purpose**: Provides advanced convective threat analysis.
-
-**Key Functions**:
-- FLOHAR (Flood Hazard Assessment) module for flood threat analysis
-- MorphoWind module for wind analysis
-- StormCast module for storm prediction
-- Region-based analysis capabilities
-
-**Final Products**:
-- Flood threat assessments
-- Wind damage potential
-- Storm forecast predictions
-- Region-specific threat information
-
-### 6. API Integration (/core/api_integration/)
-
-**Purpose**: Provides utilities for integrating with external APIs and managing data indices.
-
-**Key Functions**:
-- Manages API indices for storm cells and alerts
-- Handles API request processing
-- Provides data validation and error handling
-- Manages API versioning and deprecation
-
-**API Endpoints**:
-- `/api/stormcells` - Get current storm cells
-- `/api/alerts` - Get active alerts
-- `/api/history` - Get storm cell history
-- `/api/ctam` - Get CTAM threat assessments
-
-## Technologies Used
-
-- Python 3.13+ with NumPy/SciPy for numerical computations
-- Node.js/Express.js for API serving
-- AWS S3 for data storage
-- NOAA MRMS, ProbSevere, GOES-19 GLM, and RAP datasets
-- Shapely for spatial operations
-- Pandas for data manipulation
-- Xarray for netCDF data handling
-
-## Performance Characteristics
-
-- **Ingestion**: Handles large datasets with parallel downloading and async operations
-- **Detection**: Uses vectorized operations for fast storm cell identification
-- **Integration**: Optimizes data extraction with lazy loading and spatial indexing
-- **API**: Caches frequently accessed data for rapid response times
-
-## Error Handling and Quality Control
-
-- Data validation and consistency checks
-- Outlier detection and rejection
-- Error propagation and estimation
-- Handling of missing or incomplete data
-- Quality metrics for each integrated property
-
-## Core Module Structure
+## Directory Layout
 
 ```
-core/
-├── alerts/           # Alert generation and management
-├── api_integration/  # API integration utilities
-├── ctam/             # Convective Threat Analysis Module
-├── ingest/           # Data ingestion from various sources
-├── process/          # Data processing pipelines
-│   ├── detect/       # Storm cell detection and tracking
-│   └── integrate/    # Data integration and fusion
-└── schedule/         # Scheduling and automation
-
+src/EdgeWARN/core/
+├── alerts/           # Alert schema + manager
+├── api_integration/  # API index and snapshot helpers
+├── ctam/             # Convective Threat Analysis Module framework + modules
+├── ingest/           # Data ingestion (MRMS, NWS, synoptic, METAR)
+├── process/          # Detection + integration pipelines
+│   ├── detect/
+│   └── integrate/
+└── schedule/         # Scheduling orchestration
 ```
 
-## Modules Documentation
+## Module Responsibilities
 
-### 1. Ingestion Module (/core/ingest/)
-Responsible for collecting raw meteorological data from various sources including:
-- NOAA MRMS (Multi-Radar Multi-Sensor) data
-- NWS (National Weather Service) alerts and data
-- Synoptic data (e.g., RAP model data)
+### 1. Ingest (`core/ingest`)
+
+Collects upstream datasets used by downstream processing:
+
+- MRMS products
+- NWS alerts
+- RAP/synoptic data
 - METAR observations
+- GOES-related products via ingestion workflows
 
-### 2. Detection Module (/core/process/detect/)
-Handles storm cell detection, tracking, and lineage management using:
-- Kalman filter-based tracking
-- Lineage buffer management
-- Spatial and temporal detection algorithms
-- Alert matching and verification
+### 2. Detection (`core/process/detect`)
 
-### 3. Integration Module (/core/process/integrate/)
-Integrates and fuses data from multiple sources:
-- GOES-19 GLM lightning data
-- RAP (Rapid Refresh) synoptic data
-- MRMS radar data
-- ProbSevere v3 data
+Builds and tracks storm cells from radar/model context:
 
-### 4. Alerts Module (/core/alerts/)
-Manages alert generation and dissemination:
-- Alert schema definitions
-- Alert manager for processing and storing alerts
-- Integration with detection module
+- storm-cell detection
+- temporal association/tracking
+- Kalman-based motion support
+- lineage handling (merge/split/continuity)
 
-### 5. CTAM (Convective Threat Analysis Module) (/core/ctam/)
-Provides advanced convective threat analysis:
-- FLOHAR (Flood Hazard Assessment) module
-- MorphoWind module for wind analysis
-- StormCast module for storm prediction
-- Region-based analysis capabilities
+### 3. Integration (`core/process/integrate`)
 
-### 6. API Integration (/core/api_integration/)
-Provides utilities for integrating with external APIs and managing data indices.
+Adds environmental/contextual attributes to detected cells:
 
-### 7. Schedule (/core/schedule/)
-Manages scheduling and automation of data ingestion and processing tasks.
+- GLM lightning integration
+- RAP environmental integration
+- multi-stat raster sampling and derived feature fields
 
-## Inter-Module Relationships
+### 4. CTAM (`core/ctam`)
+
+Runs modular threat analytics on processed storm cells:
+
+- `MorphoWind`
+- `StormCast`
+- `FLOHAR`
+
+The CTAM framework provides interfaces, registry, execution engine, and history utilities.
+
+### 5. Alerts (`core/alerts`)
+
+Manages alert payload lifecycle for EdgeWARN outputs:
+
+- schema definition
+- publish/update support
+- snapshot management for API-serving directories
+
+### 6. API Integration (`core/api_integration`)
+
+Maintains API-facing index/snapshot artifacts used by the Express service.
+
+### 7. Schedule (`core/schedule`)
+
+Coordinates periodic ingestion and processing orchestration.
+
+## High-Level Data Flow
 
 ```mermaid
 graph TD
-    A[Ingestion Module] --> B[Detection Module]
-    A --> C[Integration Module]
-    B --> D[Alerts Module]
-    C --> D
-    B --> E[CTAM]
-    C --> E
-    F[API Integration] --> A
-    G[Schedule] --> A
+    A[Ingest] --> B[Detect]
+    A --> C[Integrate]
+    B --> C
+    C --> D[CTAM]
+    C --> E[Alerts]
+    D --> E
+    E --> F[API Integration]
 ```
 
-## Data Flow
+## Notes
 
-The typical data flow through the core modules is as follows:
-
-1. **Ingestion**: Raw data is collected from various sources
-2. **Detection**: Storm cells are detected and tracked
-3. **Integration**: Data from multiple sources is fused
-4. **CTAM Analysis**: Advanced threat analysis is performed
-5. **Alert Generation**: Alerts are generated based on analysis results
-6. **API Serving**: Processed data is served to frontend applications
-
-## Technologies Used
-
-- Python 3.13+ with NumPy/SciPy for numerical computations
-- Node.js/Express.js for API serving
-- AWS S3 for data storage
-- NOAA MRMS, ProbSevere, GOES-19 GLM, and RAP datasets
+- The REST API routes are implemented in `src/EdgeWARN/api`, not under `core`.
+- For route-level behavior, see `docs/api/api_endpoints.md`.
+- Detailed module references are documented in:
+  - `docs/core/ingestion.md`
+  - `docs/core/detection.md`
+  - `docs/core/integration.md`
+  - `docs/ctam/README.md`


### PR DESCRIPTION
### Motivation

- Align documentation with the actual implementation under `src/EdgeWARN/api` and `src/EdgeWARN/core` so docs accurately describe runtime behavior and on-disk structure. 
- Remove outdated/speculative content and replace it with concise, actionable references that match existing route handlers, utilities, and module layout. 

### Description

- Rewrote `docs/api/api_endpoints.md` to reflect implemented v2 API behavior including the root banner (`GET /`), dynamic version string logic, endpoint semantics for `/api/v2` and subroutes, cache headers, METAR timestamp mapping, alert ID resolution, and legacy v1 `410` responses. 
- Rewrote `docs/api/api_implementation.md` to document the actual server architecture, middleware stack (`helmet`, `compression`, `cors`, `express-rate-limit`), clustering behavior, config `BASE_DIR` resolution, file-backed routing, and `utils/fileReader` caching semantics. 
- Simplified and updated `docs/core/README.md` to summarize the real `src/EdgeWARN/core` package layout, module responsibilities (ingest, detect, integrate, ctam, alerts, api_integration, schedule), high-level data flow, and pointers to the detailed module docs. 
- Limited edits to files in `docs/` and did not change runtime code or behavior. 

### Testing

- Ran `npx prettier --write docs/api/api_endpoints.md docs/api/api_implementation.md docs/core/README.md` which completed successfully. 
- Verified formatting with `npx prettier --check docs/api/api_endpoints.md docs/api/api_implementation.md docs/core/README.md` which reported all files use Prettier code style. 
- No runtime or unit tests were modified since changes are documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b437432cd483299120fee7339116b2)