### PR TITLE
Harden RAP derived evaluation, remove debug prints, add CI and release fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - '**'
+  pull_request:
+
+jobs:
+  node-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Node.js tests
+        run: npm test
+
+  python-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-activate-base: false
+          activate-environment: EdgeWARN-dev
+          environment-file: environment.yml
+          python-version: '3.13'
+
+      - name: Run Python tests
+        shell: bash -el {0}
+        run: pytest tests -q

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check INSTALLATION.md for installation and run instructions
 
 <h2 align="center">Build Info</h2>
 
-## Current Release: **1.5.4**
+## Current Release: **2.0.0-alpha**
 
 Check [CHANGELOG.md](CHANGELOG.md) for changes
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
     - gputil
     - pytest
     - pytest-mock
+    - pytest-asyncio
     - aiofiles
     - aiohttp
     - requests

--- a/src/EdgeWARN/core/process/integrate/integrate_rap.py
+++ b/src/EdgeWARN/core/process/integrate/integrate_rap.py
@@ -2,12 +2,30 @@
 Config-driven RAP integration.
 Optimized: Zero-grid-memory extraction via eccodes RAPPointExtractor.
 """
+import ast
+import operator
+
 from .config import get_rap_products
 from util.grib_loader import RAPPointExtractor
 
 # Transformation functions
 TRANSFORMS = {
     "kelvin_to_celsius": lambda x: x - 273.15,
+}
+
+_BINARY_OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+
+_UNARY_OPERATORS = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
 }
 
 
@@ -36,11 +54,8 @@ def integrate_rap(storm_cells, rap_file_path, io_manager):
 
     # Run batch extraction
     try:
-        print(">>> [DEBUG] Before RAPPointExtractor initialization", flush=True)
         extractor = RAPPointExtractor(rap_file_path)
-        print(">>> [DEBUG] After RAPPointExtractor initialization, before extract_batch", flush=True)
         extracted_data = extractor.extract_batch(products, cell_coords)
-        print(">>> [DEBUG] After extract_batch", flush=True)
         io_manager.write_debug(f"Extracted {len(extracted_data)} keys from RAP")
     except Exception as e:
         io_manager.write_error(f"Failed to extract RAP data: {e}")
@@ -108,6 +123,50 @@ def _calculate_derived(storm_cells, formula, key):
     for cell in storm_cells:
         props = cell.get("properties", {})
         try:
-            props[key] = round(eval(formula, {"__builtins__": {}}, props), 2)
+            value = _safe_eval_formula(formula, props)
+            props[key] = round(value, 2)
         except Exception:
             props[key] = None
+
+
+def _safe_eval_formula(formula, variables):
+    """Evaluate arithmetic formulas using a restricted AST parser."""
+    expression = ast.parse(formula, mode="eval")
+    return _evaluate_node(expression.body, variables)
+
+
+def _evaluate_node(node, variables):
+    """Recursively evaluate an expression node with strict operator support."""
+    if isinstance(node, ast.BinOp):
+        operator_fn = _BINARY_OPERATORS.get(type(node.op))
+        if operator_fn is None:
+            raise ValueError("Unsupported binary operator")
+
+        left = _evaluate_node(node.left, variables)
+        right = _evaluate_node(node.right, variables)
+        if left is None or right is None:
+            raise ValueError("Cannot evaluate formula with missing values")
+
+        return operator_fn(left, right)
+
+    if isinstance(node, ast.UnaryOp):
+        operator_fn = _UNARY_OPERATORS.get(type(node.op))
+        if operator_fn is None:
+            raise ValueError("Unsupported unary operator")
+
+        operand = _evaluate_node(node.operand, variables)
+        if operand is None:
+            raise ValueError("Cannot evaluate formula with missing values")
+
+        return operator_fn(operand)
+
+    if isinstance(node, ast.Name):
+        value = variables.get(node.id)
+        if isinstance(value, (int, float)):
+            return float(value)
+        raise ValueError(f"Invalid variable value for '{node.id}'")
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return float(node.value)
+
+    raise ValueError("Unsupported expression in derived formula")

--- a/tests/core/process/integrate/test_integrate_rap.py
+++ b/tests/core/process/integrate/test_integrate_rap.py
@@ -172,3 +172,33 @@ def test_integrate_rap_empty_datasets(mock_io_manager, storm_cells):
         
     # Should return unchanged
     assert results == storm_cells
+
+
+def test_safe_eval_rejects_unsafe_formula(mock_io_manager, storm_cells):
+    """Ensure unsupported expressions are rejected and set to None."""
+    with patch("EdgeWARN.core.process.integrate.integrate_rap.get_rap_products") as mock_products, \
+         patch("EdgeWARN.core.process.integrate.integrate_rap.RAPPointExtractor") as MockExtractor:
+        mock_products.return_value = {
+            "products": [],
+            "derived": [{"formula": "__import__('os').system('echo hi')", "key": "unsafe"}]
+        }
+        MockExtractor.return_value.extract_batch.return_value = {}
+
+        results = integrate_rap(storm_cells, "dummy_path.grib2", mock_io_manager)
+
+    assert results[0]["properties"]["unsafe"] is None
+
+
+def test_safe_eval_handles_missing_input_value(mock_io_manager, storm_cells):
+    """Ensure missing variables in formulas do not crash integration."""
+    with patch("EdgeWARN.core.process.integrate.integrate_rap.get_rap_products") as mock_products, \
+         patch("EdgeWARN.core.process.integrate.integrate_rap.RAPPointExtractor") as MockExtractor:
+        mock_products.return_value = {
+            "products": [],
+            "derived": [{"formula": "temp_2m - dewpoint_2m", "key": "dewpoint_depression"}]
+        }
+        MockExtractor.return_value.extract_batch.return_value = {}
+
+        results = integrate_rap(storm_cells, "dummy_path.grib2", mock_io_manager)
+
+    assert results[0]["properties"]["dewpoint_depression"] is None


### PR DESCRIPTION
### Motivation
- Eliminate unsafe `eval` usage in RAP-derived field computation to reduce security and runtime risk when processing formulas. 
- Remove unconditional `print(...)` debug noise from the RAP pipeline and keep structured debug reporting via the existing `io_manager`. 
- Improve alpha release hygiene by aligning docs, test environment pins, and introducing a CI workflow to enforce Node/Python gates.

### Description
- Replaced `eval(...)` with a restricted AST-based evaluator implemented as `_safe_eval_formula` and `_evaluate_node` in `src/EdgeWARN/core/process/integrate/integrate_rap.py` and added explicit allowed operators. 
- Removed unconditional debug `print` statements from the RAP extraction flow and preserved structured logging through `io_manager.write_debug` in `src/EdgeWARN/core/process/integrate/integrate_rap.py`. 
- Added unit tests `test_safe_eval_rejects_unsafe_formula` and `test_safe_eval_handles_missing_input_value` to `tests/core/process/integrate/test_integrate_rap.py` to validate evaluator behavior and error-handling. 
- Updated `environment.yml` to include `pytest-asyncio`, updated `README.md` release version to `2.0.0-alpha`, and added a GitHub Actions workflow at `.github/workflows/ci.yml` to run `npm test` and `pytest tests -q` under a provisioned Conda environment.

### Testing
- Ran `npm test`, which completed successfully (Node.js test suites passed). 
- Ran `python -m py_compile src/EdgeWARN/core/process/integrate/integrate_rap.py tests/core/process/integrate/test_integrate_rap.py`, which succeeded (syntax checks passed). 
- Attempted `pytest tests/core/process/integrate/test_integrate_rap.py -q` and `pytest tests -q` in this runtime, but collection failed due to missing native/scientific runtime dependencies (e.g., `numpy`, `eccodes`), so Python tests could not be executed locally here; the added CI workflow provisions `environment.yml` before running `pytest` to address reproducibility in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b436a489b08329839f88e8656e1d3f)