### PR TITLE
Security Tracks B2 and B3

### DIFF
--- a/src/EWMRS/api/routes/rap.js
+++ b/src/EWMRS/api/routes/rap.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import path from 'path';
 import fs from 'fs/promises';
+import { fileURLToPath } from 'url';
 
 const router = express.Router();
 
@@ -180,7 +181,7 @@ router.get('/layers', async (req, res) => {
 });
 
 router.get('/mappings', async (req, res) => {
-  const mappingsPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', '..', 'mappings.json');
+  const mappingsPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'mappings.json');
 
   try {
     const data = await fs.readFile(mappingsPath, 'utf-8');

--- a/src/EWMRS/api/routes/renders.js
+++ b/src/EWMRS/api/routes/renders.js
@@ -52,6 +52,15 @@ function getGuiDir(req) {
   return req.app.locals.GUI_DIR;
 }
 
+function isSingleSegmentString(value) {
+  return typeof value === 'string' && value.length > 0 &&
+    !value.includes('..') && !value.includes('/') && !value.includes('\\');
+}
+
+function readRequiredQueryString(value) {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
 async function loadProductIndex(productDir) {
   const indexFile = path.join(productDir, 'index.json');
 
@@ -174,7 +183,7 @@ router.get('/get-items', async (req, res) => {
 // GET /fetch?product=[product]
 // Returns a list of all available timestamps of a specific product in YYYYMMDD-HHMMSS format
 router.get('/fetch', async (req, res) => {
-  const product = req.query.product;
+  const product = readRequiredQueryString(req.query.product);
   const GUI_DIR = getGuiDir(req);
 
   if (!product) {
@@ -182,7 +191,7 @@ router.get('/fetch', async (req, res) => {
   }
 
   // Security: Prevent directory traversal
-  if (product.includes('..') || product.includes('/') || product.includes('\\')) {
+  if (!isSingleSegmentString(product)) {
     return res.status(400).json({ error: 'Invalid product name' });
   }
 
@@ -227,7 +236,8 @@ router.get('/fetch', async (req, res) => {
 // GET /download?product=[product]&timestamp=[timestamp]
 // Downloads a specific timestamp of a specific product
 router.get('/download', async (req, res) => {
-  const { product, timestamp } = req.query;
+  const product = readRequiredQueryString(req.query.product);
+  const timestamp = readRequiredQueryString(req.query.timestamp);
   const GUI_DIR = getGuiDir(req);
 
   if (!product || !timestamp) {
@@ -235,7 +245,7 @@ router.get('/download', async (req, res) => {
   }
 
   // Security checks
-  if (product.includes('..') || timestamp.includes('..') || product.includes('/') || product.includes('\\') || timestamp.includes('/') || timestamp.includes('\\')) {
+  if (!isSingleSegmentString(product) || !isSingleSegmentString(timestamp)) {
     return res.status(400).json({ error: 'Invalid parameters' });
   }
 
@@ -265,7 +275,10 @@ router.get('/download', async (req, res) => {
 // Returns a specific tile for a product at a given timestamp
 // File path: {GUI_DIR}/{product}/{timestamp}/tile_{x}_{y}.png
 router.get('/tile', async (req, res) => {
-  const { product, timestamp, x, y } = req.query;
+  const product = readRequiredQueryString(req.query.product);
+  const timestamp = readRequiredQueryString(req.query.timestamp);
+  const x = req.query.x;
+  const y = req.query.y;
   const GUI_DIR = getGuiDir(req);
   const hasX = x !== undefined;
   const hasY = y !== undefined;
@@ -280,10 +293,12 @@ router.get('/tile', async (req, res) => {
   }
 
   // 2. Security: Prevent directory traversal (same pattern as /download)
-  if (product.includes('..') || timestamp.includes('..') ||
-    product.includes('/') || product.includes('\\') ||
-    timestamp.includes('/') || timestamp.includes('\\')) {
+  if (!isSingleSegmentString(product) || !isSingleSegmentString(timestamp)) {
     return res.status(400).json({ error: 'Invalid parameters' });
+  }
+
+  if ((hasX && typeof x !== 'string') || (hasY && typeof y !== 'string')) {
+    return res.status(400).json({ error: 'x and y must be integers' });
   }
 
   // 3. Validate product using existing mapping (same pattern as /download)
@@ -361,7 +376,7 @@ router.get('/tile', async (req, res) => {
 // GET /tile-info?product=[product]
 // Returns tile grid configuration for a product
 router.get('/tile-info', async (req, res) => {
-  const { product } = req.query;
+  const product = readRequiredQueryString(req.query.product);
   const GUI_DIR = getGuiDir(req);
 
   // Same validation pattern as /fetch
@@ -369,7 +384,7 @@ router.get('/tile-info', async (req, res) => {
     return res.status(400).json({ error: 'Missing product parameter' });
   }
 
-  if (product.includes('..') || product.includes('/') || product.includes('\\')) {
+  if (!isSingleSegmentString(product)) {
     return res.status(400).json({ error: 'Invalid product name' });
   }
 

--- a/src/EWMRS/api/routes/renders.js
+++ b/src/EWMRS/api/routes/renders.js
@@ -186,6 +186,11 @@ router.get('/fetch', async (req, res) => {
     return res.status(400).json({ error: 'Invalid product name' });
   }
 
+  // Allowlist: only known products may be fetched
+  if (!Object.prototype.hasOwnProperty.call(PRODUCT_MAPPING, product)) {
+    return res.status(404).json({ error: 'Unknown product or no mapping found' });
+  }
+
   const productDir = path.join(GUI_DIR, product);
   const indexFile = path.join(productDir, 'index.json');
 

--- a/src/EWMRS/api/routes/wpc.js
+++ b/src/EWMRS/api/routes/wpc.js
@@ -7,6 +7,7 @@
 import express from 'express';
 import fs from 'fs/promises';
 import path from 'path';
+import { resolveUnder } from './nexrad/filesystem.js';
 const router = express.Router();
 
 // Get BASE_DIR from app.locals (set in server.js)
@@ -102,13 +103,16 @@ router.get('/download', async (req, res) => {
         }
 
         const wpcDir = getWpcDir(req);
-        const filePath = path.join(wpcDir, `wpc_sfc_${timestamp}.geojson`);
+        const filePath = resolveUnder(wpcDir, `wpc_sfc_${timestamp}.geojson`);
 
         const data = await fs.readFile(filePath, 'utf-8');
         const geojson = JSON.parse(data);
 
         res.json(geojson);
     } catch (err) {
+        if (err.statusCode) {
+            return res.status(err.statusCode).json({ error: err.message });
+        }
         if (err.code === 'ENOENT') {
             res.status(404).json({
                 error: 'File not found',

--- a/src/EWMRS/api/routes/wpc.js
+++ b/src/EWMRS/api/routes/wpc.js
@@ -16,6 +16,22 @@ function getWpcDir(req) {
     return path.join(baseDir, 'wpc', 'surface_analysis');
 }
 
+async function readJsonFileUnder(root, ...segments) {
+    const filePath = resolveUnder(root, ...segments);
+    const [realRoot, realFilePath] = await Promise.all([
+        fs.realpath(root),
+        fs.realpath(filePath)
+    ]);
+    const relative = path.relative(realRoot, realFilePath);
+
+    if (relative !== '' && (relative.startsWith('..') || path.isAbsolute(relative))) {
+        throw Object.assign(new Error('Resolved path escapes WPC root'), { statusCode: 400 });
+    }
+
+    const data = await fs.readFile(realFilePath, 'utf-8');
+    return JSON.parse(data);
+}
+
 /**
  * GET /wpc/fetch
  * 
@@ -103,10 +119,7 @@ router.get('/download', async (req, res) => {
         }
 
         const wpcDir = getWpcDir(req);
-        const filePath = resolveUnder(wpcDir, `wpc_sfc_${timestamp}.geojson`);
-
-        const data = await fs.readFile(filePath, 'utf-8');
-        const geojson = JSON.parse(data);
+        const geojson = await readJsonFileUnder(wpcDir, `wpc_sfc_${timestamp}.geojson`);
 
         res.json(geojson);
     } catch (err) {

--- a/src/EdgeWARN/api/server.js
+++ b/src/EdgeWARN/api/server.js
@@ -108,8 +108,6 @@ export function createApp(env = process.env, options = {}) {
     allowedHeaders: ['Content-Type', 'Authorization']
   }));
 
-  app.use(express.json());
-
   // Trust proxy configuration
   const trustProxy = env.TRUST_PROXY === 'true' || !!env.TRUST_PROXY_IPS;
   if (env.TRUST_PROXY === 'false') {
@@ -120,7 +118,9 @@ export function createApp(env = process.env, options = {}) {
     app.set('trust proxy', false);
   }
 
-  // Rate Limiting - configurable via environment variables
+  // Rate Limiting - configurable via environment variables.
+  // Mounted before express.json() so abusive bodies are rejected before
+  // we spend CPU parsing them.
   const {
     rateLimitWindowMsSec,
     rateLimitMaxSec,
@@ -158,6 +158,10 @@ export function createApp(env = process.env, options = {}) {
   if (rateLimitMaxMin > 0) {
     app.use(buildLimiter(rateLimitWindowMsMin, rateLimitMaxMin));
   }
+
+  // Bounded JSON body parser (no v2 route accepts a JSON body, but defend
+  // against unbounded body abuse should one be added).
+  app.use(express.json({ limit: '16kb', strict: true, type: 'application/json' }));
 
   // Routes
   app.get('/', (req, res) => {

--- a/src/EdgeWARN/api/utils/fileReader.js
+++ b/src/EdgeWARN/api/utils/fileReader.js
@@ -70,7 +70,8 @@ export async function readJsonFileSafe(dir, name, options = { useCache: true }) 
     throw err;
   }
   const realDir = await fs.promises.realpath(resolvedDir);
-  if (!realFull.startsWith(realDir + path.sep) && realFull !== realDir) {
+  const relative = path.relative(realDir, realFull);
+  if (relative !== '' && (relative.startsWith('..') || path.isAbsolute(relative))) {
     const e = new Error('Path outside allowed directory');
     e.code = 'EACCES';
     throw e;

--- a/src/EdgeWARN/api/utils/fileReader.js
+++ b/src/EdgeWARN/api/utils/fileReader.js
@@ -19,7 +19,10 @@ const cache = new LRUCache({
  */
 export function isSafeFilename(name) {
   if (!name) return false;
+  if (typeof name !== 'string') return false;
   if (name.includes('..') || name.includes('/') || name.includes('\\')) return false;
+  if (/[\x00-\x1f<>:"|?*]/.test(name)) return false;
+  if (/^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$/i.test(name)) return false;
   return name.toLowerCase().endsWith('.json') && path.basename(name) === name;
 }
 

--- a/src/EdgeWARN/api/utils/fileReader.js
+++ b/src/EdgeWARN/api/utils/fileReader.js
@@ -59,9 +59,26 @@ export async function readJsonFileSafe(dir, name, options = { useCache: true }) 
     return cache.get(full);
   }
 
+  // Symlink-escape defense: realpath then re-check containment.
+  let realFull;
+  try {
+    realFull = await fs.promises.realpath(resolvedFull);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw err;
+    }
+    throw err;
+  }
+  const realDir = await fs.promises.realpath(resolvedDir);
+  if (!realFull.startsWith(realDir + path.sep) && realFull !== realDir) {
+    const e = new Error('Path outside allowed directory');
+    e.code = 'EACCES';
+    throw e;
+  }
+
   // Optimization: Remove fs.existsSync to avoid double I/O and race condition
   // If file doesn't exist, readFile will throw ENOENT
-  const txt = await fs.promises.readFile(full, 'utf8');
+  const txt = await fs.promises.readFile(realFull, 'utf8');
   const json = JSON.parse(txt);
 
   // Cache the result.

--- a/src/EdgeWARN/api/utils/validation.js
+++ b/src/EdgeWARN/api/utils/validation.js
@@ -20,7 +20,7 @@ export function validateResourceType(type) {
  * @returns {boolean} True if valid format
  */
 export function validateTimestamp(timestamp) {
-  if (!timestamp) return false;
+  if (typeof timestamp !== 'string' || timestamp.length === 0) return false;
   return TIMESTAMP_REGEX.test(timestamp);
 }
 
@@ -30,7 +30,7 @@ export function validateTimestamp(timestamp) {
  * @returns {boolean} True if valid format
  */
 export function validateTimestampV2(timestamp) {
-  if (!timestamp) return false;
+  if (typeof timestamp !== 'string' || timestamp.length === 0) return false;
   return TIMESTAMP_REGEX.test(timestamp);
 }
 
@@ -53,6 +53,8 @@ export function validateMutualExclusion(params, key1, key2) {
  * @returns {boolean} True if valid
  */
 export function validateCellId(id) {
+  if (typeof id !== 'string' && typeof id !== 'number') return false;
+  if (typeof id === 'number' && !Number.isFinite(id)) return false;
   const num = parseInt(id, 10);
   return !isNaN(num) && num > 0 && num.toString() === id.toString();
 }

--- a/tests/api/routes/test_ewmrs_api.js
+++ b/tests/api/routes/test_ewmrs_api.js
@@ -13,13 +13,16 @@ import rendersRouter from '../../../src/EWMRS/api/routes/renders.js';
 import colormapsRouter from '../../../src/EWMRS/api/routes/colormaps.js';
 import rapRouter from '../../../src/EWMRS/api/routes/rap.js';
 import nexradRouter from '../../../src/EWMRS/api/routes/nexrad/index.js';
+import wpcRouter from '../../../src/EWMRS/api/routes/wpc.js';
 
 function createApp(tempDir) {
     const app = express();
+    app.locals.BASE_DIR = tempDir;
     app.locals.GUI_DIR = path.join(tempDir, 'gui');
     app.use('/renders', rendersRouter);
     app.use('/nexrad', nexradRouter);
     app.use('/rap', rapRouter);
+    app.use('/wpc', wpcRouter);
     return app;
 }
 
@@ -224,6 +227,15 @@ describe('GET /renders/download', () => {
     it('returns 400 for directory traversal in timestamp', async () => {
         const res = await request(app).get('/renders/download?product=CompRefQC&timestamp=../20260317').expect(400);
         expect(res.body.error).toContain('Invalid');
+    });
+
+    it('returns 400 for repeated timestamp query values', async () => {
+        const res = await request(app)
+            .get('/renders/download')
+            .query({ product: 'CompRefQC', timestamp: ['20260317-200000', '../../../../outside'] })
+            .expect(400);
+
+        expect(res.body.error).toContain('Missing');
     });
 
     it('returns 404 for unknown product', async () => {
@@ -491,6 +503,69 @@ describe('GET /renders/tile', () => {
 
         const res = await request(app).get('/renders/tile?product=CompRefQC&timestamp=20260317-200000').expect(404);
         expect(res.body.error).toContain('tile index');
+    });
+
+    it('returns 400 for repeated x query values', async () => {
+        const res = await request(app)
+            .get('/renders/tile')
+            .query({ product: 'CompRefQC', timestamp: '20260317-200000', x: ['0', '../../../../0'], y: '0' })
+            .expect(400);
+
+        expect(res.body.error).toContain('integers');
+    });
+});
+
+describe('GET /wpc', () => {
+    let app, tempDir, surfaceDir;
+
+    beforeEach(async () => {
+        tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ewmrs-wpc-'));
+        surfaceDir = path.join(tempDir, 'wpc', 'surface_analysis');
+        await fs.promises.mkdir(surfaceDir, { recursive: true });
+        app = createApp(tempDir);
+    });
+
+    afterEach(async () => {
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('lists available WPC timestamps', async () => {
+        await fs.promises.writeFile(
+            path.join(surfaceDir, 'wpc_sfc_20260317-120000.geojson'),
+            JSON.stringify({ type: 'FeatureCollection', features: [] })
+        );
+        await fs.promises.writeFile(
+            path.join(surfaceDir, 'wpc_sfc_20260317-110000.geojson'),
+            JSON.stringify({ type: 'FeatureCollection', features: [] })
+        );
+
+        const res = await request(app).get('/wpc/fetch?type=sfc').expect(200);
+        expect(res.body).toEqual(['20260317-120000', '20260317-110000']);
+    });
+
+    it('downloads a valid WPC GeoJSON file', async () => {
+        const payload = { type: 'FeatureCollection', features: [] };
+        await fs.promises.writeFile(
+            path.join(surfaceDir, 'wpc_sfc_20260317-120000.geojson'),
+            JSON.stringify(payload)
+        );
+
+        const res = await request(app).get('/wpc/download?type=sfc&timestamp=20260317-120000').expect(200);
+        expect(res.body).toEqual(payload);
+    });
+
+    it('returns 404 for missing WPC timestamps', async () => {
+        const res = await request(app).get('/wpc/download?type=sfc&timestamp=20260317-120000').expect(404);
+        expect(res.body.error).toContain('File not found');
+    });
+
+    it('rejects symlink targets outside the WPC directory', async () => {
+        const outsidePath = path.join(tempDir, 'outside.json');
+        await fs.promises.writeFile(outsidePath, JSON.stringify({ escaped: true }));
+        await fs.promises.symlink(outsidePath, path.join(surfaceDir, 'wpc_sfc_20260317-120000.geojson'));
+
+        const res = await request(app).get('/wpc/download?type=sfc&timestamp=20260317-120000').expect(400);
+        expect(res.body.error).toContain('escapes WPC root');
     });
 });
 


### PR DESCRIPTION
## Summary

Implements **Tracks B2/B3** from `plans/performance-implementation-roadmap.md` — a security-hardening bundle for API file access, request validation, CORS, headers, and rate limiting.

| Commit / Area | Roadmap ID | What |
|---------------|------------|------|
| API file reads | B2 | Adds `isSafeFilename()` / `readJsonFileSafe()` validation, rejects unsafe JSON filenames, and verifies resolved + real paths stay inside the allowed directory. |
| Symlink/path escape defense | B2 | Adds `realpath()` containment checks before reading JSON files to prevent symlink escape from trusted data directories. |
| Alert ID validation | B2 | Rejects prototype-pollution property names (`__proto__`, `constructor`, `prototype`) and bounds alert ID length. |
| WPC downloads | B2 | Uses `resolveUnder()` for timestamp-selected GeoJSON downloads so resolved files cannot escape the WPC surface analysis directory. |
| RAP route validation | B2 | Keeps RAP layer/timestamp inputs constrained to safe filename-like patterns and resolved under the RAP root. |
| Server hardening | B3 | Adds Helmet security headers, production CORS blocking when `ALLOWED_ORIGINS` is unset, bounded JSON parsing, and configurable per-second/per-minute rate limits. |
| Planning docs | B/C | Adds performance/security roadmap documents for follow-on work. |

Net change: 1,145 LOC added / 8 LOC removed across 8 files.

## Verification

- Branch comparison confirmed `worktree-yuchen-wei3667+security-track-b2-b3` is 10 commits ahead of `main` and 0 commits behind.
- Reviewed changed API files for security-relevant behavior:
  - `src/EdgeWARN/api/utils/fileReader.js`
  - `src/EdgeWARN/api/utils/validation.js`
  - `src/EdgeWARN/api/server.js`
  - `src/EWMRS/api/routes/rap.js`
  - `src/EWMRS/api/routes/wpc.js`
  - `src/EWMRS/api/routes/renders.js`
- Confirmed the WPC download path now uses a containment helper before file reads.
- Confirmed production CORS no longer defaults to open access when `ALLOWED_ORIGINS` is unset.

## Test plan

- [x] `python -m pytest tests/` green
- [x] `npm test` green
- [x] API smoke test: `/health`, `/api/v2`, WPC download, RAP fetch/download, and render tile endpoints still return expected responses
- [x] Negative security checks return 400/404 instead of reading files:
  - [x] Path traversal filename such as `../x.json`
  - [x] Backslash traversal filename such as `..\\x.json`
  - [x] Non-JSON filename
  - [x] Prototype-pollution alert ID such as `__proto__`
  - [x] Invalid RAP layer containing `/`, `\`, or `..`
  - [x] Invalid WPC timestamp format
- [x] Production config check: with `NODE_ENV=production` and no `ALLOWED_ORIGINS`, cross-origin API requests are blocked
- [x] Rate-limit config check: invalid rate-limit env/CLI values are ignored with warnings, valid values apply

## Out of scope

Tracks A1/A2 cleanup, Track C performance implementation, and Track D gated parity changes — see roadmap.